### PR TITLE
Add option to disable message formatting

### DIFF
--- a/t/014-output-unformatted.t
+++ b/t/014-output-unformatted.t
@@ -1,0 +1,29 @@
+use Test::Most 'die';
+use Test::More::UTF8;
+use Encode;
+use JSON::MaybeXS;
+
+my $tempfile;
+
+BEGIN {
+    use Path::Tiny;
+    $tempfile = Path::Tiny->tempfile;
+}
+
+use Log::Any '$log';
+use Log::Any::Adapter 'JSON', $tempfile->opena, format_message => 0;
+
+# last line logged
+sub last_line {
+    my $line = ($tempfile->lines({ chomp => 1 }))[-1];
+    return decode_json $line;
+}
+
+##
+subtest 'message with formatting codes' => sub {
+    $log->debug('%s and %d');
+    is last_line()->{message}, '%s and %d',                           'format codes ignored';
+};
+
+##
+done_testing;


### PR DESCRIPTION
Automatic message formatting can be a bit dangerous. I happened to have dependencies that logged messages that included '%s' which wasn't intended as formatting codes, so it caused my program to crash at

```
Died: 3 scalar values are required for this pattern at /.../Log/Any/Adapter/JSON.pm line 80.
```

I'm therefore proposing a new parameter that can be used to disable message formatting. I added a test and some documentation. I'm very unfamiliar with Perl though, so just let me know if there's something that should be improved!

Btw. I wasn't quite sure where to add the documentation for the parameter, so I created a new section, where I also added documentation for `log_level`.